### PR TITLE
fix issue #17 : Redefining a deferred block that is not the first removes other blocks from rendering

### DIFF
--- a/src/DeferredMarkIfFirstNode.php
+++ b/src/DeferredMarkIfFirstNode.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the rybakit/twig-deferred-extension package.
+ *
+ * (c) Eugene Leonovich <gen.work@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Twig\DeferredExtension;
+
+use Twig\Compiler;
+use Twig\Node\Node;
+
+final class DeferredMarkIfFirstNode extends Node
+{
+    public function compile(Compiler $compiler) : void
+    {
+        $compiler
+            ->write("\$this->deferred->markIfFirst(\$this);\n")
+        ;
+    }
+}

--- a/src/DeferredNodeVisitor.php
+++ b/src/DeferredNodeVisitor.php
@@ -35,6 +35,7 @@ final class DeferredNodeVisitor implements NodeVisitorInterface
     {
         if ($this->hasDeferred && $node instanceof ModuleNode) {
             $node->getNode('constructor_end')->setNode('deferred_initialize', new DeferredInitializeNode());
+            $node->getNode('display_start')->setNode('deferred_markiffirst', new DeferredMarkIfFirstNode());
             $node->getNode('display_end')->setNode('deferred_resolve', new DeferredResolveNode());
             $node->getNode('class_end')->setNode('deferred_declare', new DeferredDeclareNode());
             $this->hasDeferred = false;

--- a/tests/Fixtures/parents2.1.test
+++ b/tests/Fixtures/parents2.1.test
@@ -1,0 +1,17 @@
+--TEST--
+parents
+--TEMPLATE--
+{% extends "level1.twig" %}
+{% block overrided deferred %}{{ parent() }}:level2({{data|join(', ')}}){% endblock %}
+{% do data.append('lazy2') %}
+--TEMPLATE(level1.twig)--
+{% block bar '[bar]' %}
+{% block foo deferred %}[foo({{data|join(', ')}})]{% endblock %}
+{% block baz '[baz]' %}
+{% block overrided deferred %}[overrided({{data|join(', ')}})]{% endblock %}
+{% block zoo '[zoo]' %}
+{% do data.append('lazy1') %}
+--DATA--
+return []
+--EXPECT--
+[bar][foo(lazy2, lazy1)][baz][overrided(lazy2, lazy1)]:level2(lazy2, lazy1)[zoo]

--- a/tests/Fixtures/parents2.test
+++ b/tests/Fixtures/parents2.test
@@ -1,0 +1,18 @@
+--TEST--
+parents
+--TEMPLATE--
+{% extends "level1.twig" %}
+{% block foo deferred %}{{ parent() }}:f2({{data|join(', ')}}){% endblock %}
+{% block overrided deferred %}{{ parent() }}:level2({{data|join(', ')}}){% endblock %}
+{% do data.append('lazy2') %}
+--TEMPLATE(level1.twig)--
+{% block bar '[bar]' %}
+{% block foo deferred %}[foo({{data|join(', ')}})]{% endblock %}
+{% block baz '[baz]' %}
+{% block overrided deferred %}[overrided({{data|join(', ')}})]{% endblock %}
+{% block zoo '[zoo]' %}
+{% do data.append('lazy1') %}
+--DATA--
+return []
+--EXPECT--
+[bar][foo(lazy2, lazy1)]:f2(lazy2, lazy1)[baz][overrided(lazy2, lazy1)]:level2(lazy2, lazy1)[zoo]

--- a/tests/Fixtures/parents3.1.test
+++ b/tests/Fixtures/parents3.1.test
@@ -1,0 +1,12 @@
+--TEST--
+parents
+--TEMPLATE--
+{% extends "level1.twig" %}
+{% block overrided deferred %}{{ parent() }}:level2{% endblock %}
+--TEMPLATE(level1.twig)--
+{% block foo deferred %}[foo]{% endblock %}
+{% block overrided deferred %}[overrided]{% endblock %}
+--DATA--
+return []
+--EXPECT--
+[foo][overrided]:level2

--- a/tests/Fixtures/parents3.test
+++ b/tests/Fixtures/parents3.test
@@ -1,0 +1,13 @@
+--TEST--
+parents
+--TEMPLATE--
+{% extends "level1.twig" %}
+{% block foo deferred %}{{ parent() }}:f2{% endblock %}
+{% block overrided deferred %}{{ parent() }}:level2{% endblock %}
+--TEMPLATE(level1.twig)--
+{% block foo deferred %}[foo]{% endblock %}
+{% block overrided deferred %}[overrided]{% endblock %}
+--DATA--
+return []
+--EXPECT--
+[foo]:f2[overrided]:level2


### PR DESCRIPTION
The logic of this fix to issue #17  is to resolve deferred blocks only at the end of all rendering process.
This is to fix order of buffering layers closing.
